### PR TITLE
Olympian stats endpoint

### DIFF
--- a/app/controllers/api/v1/olympian_stats_controller.rb
+++ b/app/controllers/api/v1/olympian_stats_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::OlympianStatsController < ApplicationController
+	def show
+    facade = OlympianStats.new
+    render json: (facade), serializer: OlympianStatsSerializer
+	end
+end
+

--- a/app/facades/olympian_stats.rb
+++ b/app/facades/olympian_stats.rb
@@ -6,11 +6,11 @@ class OlympianStats
     Olympian.total_competing_olympians
   end
 
-  #def average_weight
-  #  Olympian.average_weight
-  #end
+  def average_weight(sex)
+    Olympian.average_weight(sex)
+  end
 
-  #def average_age
-  #  Olympian.average_age
-  #end
+  def average_age
+    Olympian.average_age
+  end
 end

--- a/app/facades/olympian_stats.rb
+++ b/app/facades/olympian_stats.rb
@@ -1,0 +1,16 @@
+class OlympianStats
+  include ActiveModel::Serialization
+  def initialize; end
+
+  def total_competing_olympians
+    Olympian.total_competing_olympians
+  end
+
+  #def average_weight
+  #  Olympian.average_weight
+  #end
+
+  #def average_age
+  #  Olympian.average_age
+  #end
+end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -19,4 +19,12 @@ class Olympian < ApplicationRecord
   def self.total_competing_olympians
     count
   end
+
+  def self.average_weight(sex)
+    where(sex: sex).average(:weight).to_f.round(1)
+  end
+
+  def self.average_age
+    average(:age).to_f.round(1)
+  end
 end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -15,4 +15,8 @@ class Olympian < ApplicationRecord
   def self.oldest
     order(age: :desc).first
   end
+
+  def self.total_competing_olympians
+    count
+  end
 end

--- a/app/serializers/olympian_stats_serializer.rb
+++ b/app/serializers/olympian_stats_serializer.rb
@@ -1,0 +1,7 @@
+class OlympianStatsSerializer < ActiveModel::Serializer
+  attributes :total_competing_olympians #, :average_weight, :average_age
+
+  def total_competing_olympians
+    self.object.total_competing_olympians
+  end
+end

--- a/app/serializers/olympian_stats_serializer.rb
+++ b/app/serializers/olympian_stats_serializer.rb
@@ -1,7 +1,19 @@
 class OlympianStatsSerializer < ActiveModel::Serializer
-  attributes :total_competing_olympians #, :average_weight, :average_age
+  attributes :total_competing_olympians, :average_weight, :average_age
 
   def total_competing_olympians
     self.object.total_competing_olympians
+  end
+
+  def average_weight
+    { 
+      "unit": "kg",
+      "male_olympians": self.object.average_weight('M'),
+      "female_olympians": self.object.average_weight('F')
+    }
+  end
+    
+  def average_age
+    self.object.average_age
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/olympians', to: 'olympians#index'
+      get '/olympian_stats', to: 'olympian_stats#show'
     end
   end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Olympian, type: :model do
       sex: "M",
       age: 42,
       height: 190,
-      weight: 140,
+      weight: 150,
       team: 'USA'
     }
     sport = Sport.create!(name: 'competitive painting')
@@ -19,7 +19,7 @@ RSpec.describe Olympian, type: :model do
       sex: "M",
       age: 22,
       height: 160,
-      weight: 110,
+      weight: 50,
       team: 'USA'
     }
     sport_2 = Sport.create!(name: 'competitive dancing')
@@ -30,7 +30,7 @@ RSpec.describe Olympian, type: :model do
       sex: "F",
       age: 12,
       height: 120,
-      weight: 190,
+      weight: 100,
       team: 'Russia'
     }
     
@@ -114,6 +114,19 @@ RSpec.describe Olympian, type: :model do
 
     it '.total_competing_olympians' do
       expect(Olympian.total_competing_olympians).to eq(3)
+    end
+
+    it '.average_weight' do
+      expected_1 = (@olympian_1.weight + @olympian_2.weight) / 2
+      expect(Olympian.average_weight('M')).to eq(expected_1)
+
+      expected_2 = @olympian_3.weight
+      expect(Olympian.average_weight('F')).to eq(expected_2)
+    end
+
+    it '.average_age' do
+      expected = Olympian.pluck(:age).sum.to_f / Olympian.count
+      expect(Olympian.average_age).to eq(expected.round(1))
     end
   end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -111,5 +111,9 @@ RSpec.describe Olympian, type: :model do
     it '.oldest' do
       expect(Olympian.oldest).to eq(@olympian_1)
     end
+
+    it '.total_competing_olympians' do
+      expect(Olympian.total_competing_olympians).to eq(3)
+    end
   end
 end

--- a/spec/requests/api/v1/olympian_stats_request_spec.rb
+++ b/spec/requests/api/v1/olympian_stats_request_spec.rb
@@ -8,7 +8,7 @@ describe "olympian stats api" do
       sex: "M",
       age: 42,
       height: 190,
-      weight: 140,
+      weight: 150,
       team: 'USA'
     }
     sport = Sport.create!(name: 'competitive painting')
@@ -19,7 +19,7 @@ describe "olympian stats api" do
       sex: "M",
       age: 22,
       height: 160,
-      weight: 110,
+      weight: 50,
       team: 'USA'
     }
     sport_2 = Sport.create!(name: 'competitive dancing')
@@ -30,7 +30,7 @@ describe "olympian stats api" do
       sex: "F",
       age: 12,
       height: 120,
-      weight: 190,
+      weight: 100,
       team: 'Russia'
     }
     
@@ -89,6 +89,10 @@ describe "olympian stats api" do
 
     stat_data = JSON.parse(response.body)
     expect(stat_data["olympian_stats"]["total_competing_olympians"]).to eq(3)
+    expect(stat_data["olympian_stats"]["average_weight"]["unit"]).to eq("kg")
+    expect(stat_data["olympian_stats"]["average_weight"]["male_olympians"]).to eq(Olympian.average_weight(male))
+    expect(stat_data["olympian_stats"]["average_weight"]["female_olympians"]).to eq(Olympian.average_weight(female))
+    expect(stat_data["olympian_stats"]["average_age"]).to eq(Olympian.average_age)
 	end
 end
 

--- a/spec/requests/api/v1/olympian_stats_request_spec.rb
+++ b/spec/requests/api/v1/olympian_stats_request_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+describe "olympian stats api" do
+	before :each do
+	  ##olympian_data
+    olympian_1_attrs = {
+      name: "Bob Ross",
+      sex: "M",
+      age: 42,
+      height: 190,
+      weight: 140,
+      team: 'USA'
+    }
+    sport = Sport.create!(name: 'competitive painting')
+    @olympian_1 = sport.olympians.create!(olympian_1_attrs)
+    
+    olympian_2_attrs = {
+      name: "Prince",
+      sex: "M",
+      age: 22,
+      height: 160,
+      weight: 110,
+      team: 'USA'
+    }
+    sport_2 = Sport.create!(name: 'competitive dancing')
+    @olympian_2 = sport_2.olympians.create!(olympian_2_attrs)
+
+    olympian_3_attrs = {
+      name: "Garth Brooks",
+      sex: "F",
+      age: 12,
+      height: 120,
+      weight: 190,
+      team: 'Russia'
+    }
+    
+    sport_3 = Sport.create!(name: 'competitive yodling')
+    @olympian_3 = sport_3.olympians.create!(olympian_3_attrs)
+
+    ##Event data
+    event_1a_attrs = {
+      name: "bird draw",
+      games: "2020 couch party",
+    } 
+    
+    event_1b_attrs = {
+      name: "cloud draw",
+      games: "2020 couch party",
+    } 
+    
+    event_1c_attrs = {
+      name: "star draw",
+      games: "2020 couch party",
+    } 
+    
+    olympian_event_1a_attrs = {
+      medal: "NA"
+    }
+    olympian_event_1b_attrs = {
+      medal: "Gold"
+    }
+    olympian_event_1c_attrs = {
+      medal: "Bronze"
+    }
+    
+    
+    event_1a = sport.events.create!(event_1a_attrs)
+    event_1b = sport.events.create!(event_1b_attrs)
+    event_1c = sport.events.create!(event_1c_attrs)
+    
+    olympian_event_1a = @olympian_1.olympian_events.new(olympian_event_1a_attrs)
+    olympian_event_1a.event = event_1a
+    olympian_event_1a.save
+    
+    olympian_event_1b = @olympian_1.olympian_events.new(olympian_event_1b_attrs)
+    olympian_event_1b.event = event_1b
+    olympian_event_1b.save
+    
+    olympian_event_1c = @olympian_1.olympian_events.new(olympian_event_1c_attrs)
+    olympian_event_1c.event = event_1c
+    olympian_event_1c.save
+
+	end
+	
+	it "returns a list of olympian statistics" do
+	  get '/api/v1/olympian_stats'	
+
+    expect(response).to be_successful
+
+    stat_data = JSON.parse(response.body)
+    expect(stat_data["olympian_stats"]["total_competing_olympians"]).to eq(3)
+	end
+end
+

--- a/spec/requests/api/v1/olympian_stats_request_spec.rb
+++ b/spec/requests/api/v1/olympian_stats_request_spec.rb
@@ -90,8 +90,8 @@ describe "olympian stats api" do
     stat_data = JSON.parse(response.body)
     expect(stat_data["olympian_stats"]["total_competing_olympians"]).to eq(3)
     expect(stat_data["olympian_stats"]["average_weight"]["unit"]).to eq("kg")
-    expect(stat_data["olympian_stats"]["average_weight"]["male_olympians"]).to eq(Olympian.average_weight(male))
-    expect(stat_data["olympian_stats"]["average_weight"]["female_olympians"]).to eq(Olympian.average_weight(female))
+    expect(stat_data["olympian_stats"]["average_weight"]["male_olympians"]).to eq(Olympian.average_weight('M'))
+    expect(stat_data["olympian_stats"]["average_weight"]["female_olympians"]).to eq(Olympian.average_weight('F'))
     expect(stat_data["olympian_stats"]["average_age"]).to eq(Olympian.average_age)
 	end
 end


### PR DESCRIPTION
## Changes proposed in this pull request:
* This PR adds all specs and functionality for the `GET /api/v1/olympian_stats` endpoint.  It adds the class methods for average age, average weight, and total competing olympians.  A serializer is customized to read and display the olympian_stat facade per spec outlines.  

## Card(s) closed in this pull request:
close #8 

## What did you struggle on to complete?
* Customizing the API output with the serializer was a bit complicated

## Current Test Suite:
### Overall Test Coverage: 100%
### Model Test Coverage: 100%
- [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
- [x] Checked coverage/index.html - did not add any new code that's not covered by testing (if possible)
- [x] Ran the test suite - all tests are passing
- [x] Merged in the latest master to my branch & resolved merge conflicts